### PR TITLE
Feat-issue 58

### DIFF
--- a/backend/user-service/src/main/java/com/tadak/userservice/domain/member/service/MemberService.java
+++ b/backend/user-service/src/main/java/com/tadak/userservice/domain/member/service/MemberService.java
@@ -73,11 +73,6 @@ public class MemberService {
     }
 
     public ResponseEntity<TokenResponseDto> login(LoginRequestDto loginRequestDto) {
-        Member member = memberRepository.findByEmail(loginRequestDto.getEmail())
-                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER_ERROR));
-
-        validMemberState(member); // member State 검증
-
         Authentication authentication = getAuthentication(loginRequestDto);
 
         String accessToken = tokenProvider.createAccessToken(authentication);
@@ -159,15 +154,6 @@ public class MemberService {
         }
     }
 
-    /**
-     * Member state 검증
-     * @param member
-     */
-    private static void validMemberState(Member member) {
-        if (member.getState() == State.DELETE){
-            throw new MemberStateException(ErrorCode.NOT_VALID_MEMBER_STATE_ERROR);
-        }
-    }
 
     /**
      * loginMember 검증

--- a/backend/user-service/src/main/java/com/tadak/userservice/global/security/userdetail/CustomUserDetailsService.java
+++ b/backend/user-service/src/main/java/com/tadak/userservice/global/security/userdetail/CustomUserDetailsService.java
@@ -2,7 +2,9 @@ package com.tadak.userservice.global.security.userdetail;
 
 import com.tadak.userservice.domain.member.entity.Member;
 import com.tadak.userservice.domain.member.entity.State;
+import com.tadak.userservice.domain.member.exception.MemberStateException;
 import com.tadak.userservice.domain.member.repository.MemberRepository;
+import com.tadak.userservice.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -34,7 +36,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private UserDetails createMember(String username, Member member) {
         if (!member.getState().equals(State.ACTIVE)) {
-            throw new RuntimeException(username + " -> 활성화되어 있지 않습니다.");
+            throw new MemberStateException(ErrorCode.NOT_VALID_MEMBER_STATE_ERROR);
         }
 
 //        List<GrantedAuthority> grantedAuthorities = member.getMemberAuthorities().stream()


### PR DESCRIPTION
### ✨ 작업 내용
---

- [x] Member state 중복 로직 제거

### ✨ 참고 사항
---

```java
        Member member = memberRepository.findByEmail(loginRequestDto.getEmail())
                .orElseThrow(() -> new NotFoundMemberException(ErrorCode.NOT_FOUND_MEMBER_ERROR));

        validMemberState(member); // member State 검증
```

로그인할 경우 select 되는 필요없는 query 삭제

### ⏰ 현재 버그
---

### ✏ Git Close
---

close #58 