### PR TITLE
Feat/issue-83

### DIFF
--- a/backend/user-service/src/main/java/com/tadak/userservice/domain/member/dto/response/TokenResponseDto.java
+++ b/backend/user-service/src/main/java/com/tadak/userservice/domain/member/dto/response/TokenResponseDto.java
@@ -22,5 +22,4 @@ public class TokenResponseDto {
     private String accessToken;
     @JsonIgnore
     private String refreshToken;
-    private LocalDateTime tokenCreateAt;
 }

--- a/backend/user-service/src/main/java/com/tadak/userservice/global/jwt/provider/TokenProvider.java
+++ b/backend/user-service/src/main/java/com/tadak/userservice/global/jwt/provider/TokenProvider.java
@@ -101,7 +101,6 @@ public class TokenProvider implements InitializingBean {
                 .grantType("Bearer")
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .tokenCreateAt(LocalDateTime.now())
                 .build();
     }
 

--- a/backend/user-service/src/main/java/com/tadak/userservice/global/oauth/OAuth2MemberSuccessHandler.java
+++ b/backend/user-service/src/main/java/com/tadak/userservice/global/oauth/OAuth2MemberSuccessHandler.java
@@ -46,13 +46,13 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         TokenResponseDto tokenResponseDto = tokenProvider.createTokenResponseDto(accessToken, refreshToken);
 
         createResponseHeader(response, tokenResponseDto);
+
+        response.sendRedirect("http://localhost:5173");
     }
 
     private void createResponseHeader(HttpServletResponse response, TokenResponseDto tokenResponseDto) throws IOException {
         response.addHeader(JwtFilter.ACCESS_AUTHORIZATION_HEADER, "Bearer " + tokenResponseDto.getAccessToken());
         response.addHeader(JwtFilter.REFRESH_AUTHORIZATION_HEADER, "Bearer " + tokenResponseDto.getRefreshToken());
-        new ObjectMapper().writeValue(response.getWriter(), tokenResponseDto);
-        response.flushBuffer();
     }
 
     private List<GrantedAuthority> getGrantedAuthorities(Member member) {

--- a/backend/user-service/src/main/java/com/tadak/userservice/global/oauth/OAuthAttributes.java
+++ b/backend/user-service/src/main/java/com/tadak/userservice/global/oauth/OAuthAttributes.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
+import java.util.UUID;
 
 @Getter
 @ToString
@@ -45,6 +46,7 @@ public class OAuthAttributes {
         return Member.builder()
                 .username(name)
                 .email(email)
+                .password(UUID.randomUUID().toString()) // 임시 비밀번호 UUID로 생성
                 .state(State.ACTIVE)
                 .role(Role.ROLE_USER)
                 .build();

--- a/backend/user-service/src/main/resources/application.yml
+++ b/backend/user-service/src/main/resources/application.yml
@@ -26,3 +26,8 @@ jwt:
   secret: WkhJMjVlYXo4V25xdGxaNW12WFdTRTZTamMwekt5V0FFNHVjdmFUOUM0R2tKQTVCTEw0WTlsYWo5OE5DdGpaWg==
   access-validity-in-seconds: 3600
   refresh-validity-in-seconds: 604800
+
+# logging
+logging:
+  level:
+    org.springframework.security: trace


### PR DESCRIPTION
### ✨ 작업 내용
---

- [x] OAuth 네이버 로그인 성공

### ✨ 참고 사항
---

현재 프론트에서는 url만 전달해주고 로직 처리는 security 환경에서 처리하도록 하였습니다.
`<a href='[http://localhost:8001/oauth2/authorization/naver'>naver](http://localhost:8001/oauth2/authorization/naver'%3Enaver) 로그인</a>`
를 통해 서버로 로그인만 처리해서 accessToken과 refreshToken을 전달해주는 형식으로 하였습니다.

### ⏰ 현재 버그
---

### ✏ Git Close
---

close #83 